### PR TITLE
Update an01009.rst

### DIFF
--- a/doc/rst/an01009.rst
+++ b/doc/rst/an01009.rst
@@ -215,13 +215,14 @@ XUD normally sets ``set_thread_fast_mode_on()`` which improves IO timings in the
 However it also increases power consumption because the thread is always scheduled, even when waiting on an event. In low-power
 USB audio applications it can be acceptable to disable fast mode. 
 
-The below file is included by ``lib_xud`` and uses a macro to remove the call to ``set_thread_fast_mode_on()``.
+The file ``xud_conf.h`` is included by ``lib_xud`` and you in that file define
+a macro to remove the call to ``set_thread_fast_mode_on()``.
 
  .. literalinclude:: ../../app_an01009/src/extensions/xud_conf.h
     :language: c
     :name: xud_thread_mode
-    :start-at: #ifdef LOW_POWER_ENABLE
-    :end-at: #endif
+    :start-after: #ifdef LOW_POWER_ENABLE
+    :end-before: #endif
 
 In addition, to ensure that XUD always receives sufficient MIPS in the cases where more than 5 hardware threads
 are used on the XUD tile, the following define is set in the ``CMakeLists.txt``::


### PR DESCRIPTION
This change makes it clearer what you need to do to hobble lib_xud. It would be very very nice if -DXUD_PRIORITY_HIGH=1 did just not set it to fast mode. Ie, it switches between fast mode (the default) or priority mode (low power)